### PR TITLE
🎉🎊🍾 [New Feature] (config) Add PR template config for GitHub project.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+#### Pre-Checking
+
+‼️Please must read this section and check by yourself.
+⚠️Do NOT modify this section if it doesn't have any necessary reason.
+
+Please verify the PR header should be satisfied below format: 
+    
+    [commit topic] (commit scope) <commit summary>
+
+* commit topic: The major topic of your modify. It could have multiple topics, e.g., [Breaking Change + Test].
+* commit scope: The scope in project of modify. It could have multiple scopes, e.g., (config + test).
+* commit summary: Summary of the commits. It should be clear that the target, the KEY POINT why you modify it or what you resolve, etc.
+
+Please refer to [GCR (Git Commit Rules) of SmoothCrawler-AppIntegration](../../.gitcommitrules) to get more detail about it.
+
+<hr>
+
+### _Target_
+
+* The target why you modify something.
+
+
+### _Modify Code Scope_
+
+* The more details of project scope which be modified, e.g., (refer to below 2 example items)
+* Which sub-packages or modules or objects or functions, etc., in **source code**.
+* Which sub-packages or modules or objects or functions, etc., in **test**.
+
+
+### _Effecting Scope_
+
+* What's the scope in project it would affect with your modify? The format could refer to previous one section.
+
+
+### _Description_
+
+* the summary of your modify ...

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 Bryant Liu
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
#### Pre-Checking

‼️Please must read this section and check by yourself.
⚠️Do NOT modify this section if it doesn't have any necessary reason.

Please verify the PR header should be satisfied below format: 
    
    [commit topic] (commit scope) <commit summary>

* commit topic: The major topic of your modify. It could have multiple topics, e.g., [Breaking Change + Test].
* commit scope: The scope in project of modify. It could have multiple scopes, e.g., (config + test).
* commit summary: Summary of the commits. It should be clear that the target, the KEY POINT why you modify it or what you resolve, etc.

Please refer to [GCR (Git Commit Rules) of SmoothCrawler-Cluster](../../.gitcommitrules) to get more detail about it.

<hr>

### _Target_

* Add PR template config of this GitHub project for ruling what content format it should have.


### _Modify Code Scope_

* All settings in **_.github_** directory.

    * Template of PR content setting in **_.github_**.


### _Effecting Scope_

* The all automations after developers pushes their commits to GitHub platform.


### _Description_

* _Template of PR content_: 

    * Modify the template file path to implement PR template feature (not sure work finely).

